### PR TITLE
fix: --threshold above 0.35 was silently ignored in all three confidence gates

### DIFF
--- a/src/cli/cli_app.cpp
+++ b/src/cli/cli_app.cpp
@@ -393,7 +393,10 @@ void process_single_advanced(
             DetectionResult det = engine.detect_watermark(image, force_size, force_variant);
             confidence = det.confidence;
 
-            if (det.detected || det.confidence >= detection_threshold) {
+            // detection_threshold alone gates the decision; det.detected is a
+            // fixed-threshold label for logging only (see watermark_engine.cpp
+            // process_image for the full rationale).
+            if (det.confidence >= detection_threshold) {
                 active_variant = det.variant;
                 // Standard detection succeeded
                 auto config = get_watermark_config(img_w, img_h, active_variant);

--- a/src/core/watermark_engine.cpp
+++ b/src/core/watermark_engine.cpp
@@ -1146,8 +1146,11 @@ ProcessResult process_image(
             DetectionResult detection = engine.detect_watermark(image, force_size, force_variant);
             result.confidence = detection.confidence;
 
-            const bool ncc_passes = detection.detected ||
-                                    detection.confidence >= detection_threshold;
+            // The caller-supplied threshold is the sole safety gate here.
+            // `detection.detected` reflects a fixed internal threshold used
+            // for logging/labeling only -- ORing it in would make any
+            // detection_threshold above that fixed value a no-op.
+            const bool ncc_passes = detection.confidence >= detection_threshold;
             if (!ncc_passes) {
                 result.skipped = true;
                 result.success = true;  // Not an error, just skipped

--- a/src/gui/app/app_controller.cpp
+++ b/src/gui/app/app_controller.cpp
@@ -719,8 +719,12 @@ void AppController::process_batch_file(BatchFileResult& result) {
         try {
             DetectionResult det = m_engine->detect_watermark(image, force_size, variant);
             result.confidence = det.confidence;
+            // det.detected uses a fixed internal threshold for logging only;
+            // the user-adjustable slider (m_state.batch.detection_threshold)
+            // must be the sole gate or raising it above that fixed value
+            // becomes a no-op.
             const bool ncc_passes =
-                det.detected || det.confidence >= m_state.batch.detection_threshold;
+                det.confidence >= m_state.batch.detection_threshold;
             if (!ncc_passes) {
                 result.status = BatchFileStatus::Skipped;
                 result.message = fmt::format("No watermark detected ({:.0f}%), skipped",


### PR DESCRIPTION
## Summary

`process_image()` (CLI simple/standard mode), `process_single_advanced()`
(CLI advanced pipeline), and `AppController::process_batch_file()` (GUI
batch mode) all gate watermark removal with:

```cpp
const bool ncc_passes = detection.detected || detection.confidence >= detection_threshold;
```

`detection.detected` is set inside `detect_one_variant()` against a fixed
internal constant (`kDetectionThreshold = 0.35f`), independent of the
caller-supplied `detection_threshold` (`--threshold` / the GUI slider).

Because of the `OR`, any image scoring >= 35% confidence passes the gate
regardless of how high the user sets `--threshold`. Concretely:
`GeminiWatermarkTool --threshold 0.90 -i in.jpg -o out.jpg` still processes
an image at 40% confidence, even though the user explicitly asked for a
90% bar before touching the file. Only lowering the threshold below 0.35
ever had an effect — raising it above 0.35 was a no-op in all three call
sites. This silently undermines the documented safety contract ("images
below this score are skipped").

## Fix

Make `confidence >= detection_threshold` the sole gate in all three
locations. `detection.detected` is left untouched and still used for its
original purpose (the "DETECTED"/"not detected" debug/log label).

At the CLI/GUI default threshold of 0.25 (which is below the fixed 0.35),
behavior is unchanged — this only affects users who explicitly raise the
threshold above 0.35.

## Test plan

- [ ] Build (not verified in this PR — the change is a pure boolean-logic
      edit with no new symbols/includes; happy to run the CI matrix if
      preferred over a manual build)
- [ ] Manual repro: run `--threshold 0.90` against a sample image with
      confidence in the 35–89% range before/after the patch and confirm
      it now skips instead of processing
- [ ] Confirm default-threshold (0.25) behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)